### PR TITLE
 Add "Brand Icons" category to "Creative Commons" icon categories

### DIFF
--- a/src/icons.yml
+++ b/src/icons.yml
@@ -5564,7 +5564,7 @@ icons:
     created:    4.4
     categories:
       - Web Application Icons
-
+      - Brand Icons
 
   - name:       GG Currency
     id:         gg


### PR DESCRIPTION
Classify the Creative Commons logo as a brand icon